### PR TITLE
Add support for opening a specific command UI tab on button click

### DIFF
--- a/src/ashlib/data/plugins/coreui/CommandTabInterceptor.java
+++ b/src/ashlib/data/plugins/coreui/CommandTabInterceptor.java
@@ -8,6 +8,21 @@ import com.fs.starfarer.api.campaign.listeners.PlayerColonizationListener;
 
 
 public class CommandTabInterceptor implements CoreUITabListener, PlayerColonizationListener {
+    /*
+    We need this because if the player has the colony management screen open, the "param" argument gets overridden
+    by the MarketAPI object even if you try to set the argument yourself, like the below snippet:
+
+    CommandCustomData commandCustomData = new CommandCustomData("terraforming", null);
+    Global.getSector().getCampaignUI().showCoreUITab(CoreUITabId.OUTPOSTS, commandCustomData);
+
+     With the param argument getting overridden with the MarketAPI object, we must use some other mechanism to track
+     which tab to open, so I'm using this static variable here. To use this, the following snippet works:
+
+     import ashlib.data.plugins.coreui.CommandTabInterceptor;
+     CommandTabInterceptor.tabIdToSwitchToUponOpen = "terraforming";
+     */
+    public static String tabIdToSwitchToUponOpen = null;
+
     @Override
     public void reportAboutToOpenCoreTab(CoreUITabId tab, Object param) {
         if (param instanceof String) {
@@ -24,6 +39,11 @@ public class CommandTabInterceptor implements CoreUITabListener, PlayerColonizat
             if(data.getSubTabId()!=null){
                 CommandTabMemoryManager.getInstance().getTabStates().put(data.getCommandId(),data.getSubTabId());
             }
+        }
+        if(tabIdToSwitchToUponOpen != null)
+        {
+            CommandTabMemoryManager.getInstance().setLastCheckedTab(tabIdToSwitchToUponOpen);
+            tabIdToSwitchToUponOpen = null;
         }
         CommandTabTracker.sendSignalToOpenCore = true;
     }

--- a/src/ashlib/data/plugins/coreui/CommandTabTracker.java
+++ b/src/ashlib/data/plugins/coreui/CommandTabTracker.java
@@ -320,6 +320,14 @@ public class CommandTabTracker implements EveryFrameScript {
     transient ButtonAPI currentTab = null;
     transient public LinkedHashMap<String, CommandUIPlugin> additionalPlugins = new LinkedHashMap<>();
     String currMusicId;
+    /*
+     Allows CommandUIPlugin classes from other mods to set an object that will be passed to the init() method on their plugin.
+     For example, TASC's terraforming menu supports opening a particular market when the tab is switched to.
+     This is used to allow the player to open the terraforming menu with a particular colony already selected to save them
+     the hassle of navigating to it manually.
+     TASC uses this commandUiPluginArgument variable to track which market to open when the terraforming tab is opened.
+    */
+    public static Object commandUiPluginArgument = null;
 
     @Override
     public boolean isDone() {
@@ -438,7 +446,12 @@ public class CommandTabTracker implements EveryFrameScript {
             for (CommandTabListener listener : listeners) {
 
                 CommandUIPlugin plugin = listener.createPlugin();
-                plugin.init(CommandTabMemoryManager.getInstance().getTabStates().get(listener.getNameForTab().toLowerCase()), mainParent);
+                if(commandUiPluginArgument != null) {
+                    plugin.init(CommandTabMemoryManager.getInstance().getTabStates().get(listener.getNameForTab().toLowerCase()), mainParent, commandUiPluginArgument);
+                }
+                else {
+                    plugin.init(CommandTabMemoryManager.getInstance().getTabStates().get(listener.getNameForTab().toLowerCase()), mainParent);
+                }
                 panelMap.put(tryToGetButtonProd(listener.getNameForTab().toLowerCase()), plugin.getMainPanel());
                 if(additionalPlugins==null)additionalPlugins = new LinkedHashMap<>();
                 additionalPlugins.put(listener.getNameForTab().toLowerCase(), plugin);

--- a/src/ashlib/data/plugins/coreui/CommandUIPlugin.java
+++ b/src/ashlib/data/plugins/coreui/CommandUIPlugin.java
@@ -296,6 +296,33 @@ public class CommandUIPlugin implements ExtendedUIPanelPlugin {
         return false;
     }
 
+    public void init(String panelToShowcase,Object data, Object customData)
+    {
+        /*
+         You can implement some custom logic using customData here (e.g. a market, a ship, etc.)
+         in your override in your CommandUIPlugin extension. The below snippet is working for TASC:
+
+        @Override
+        public void init(String panelToShowcase, Object data, Object customData)
+        {
+            if(customData instanceof MarketAPI)
+            {
+                init((MarketAPI) customData);
+            }
+            else
+            {
+                init(null);
+            }
+        }
+
+        @Override
+        public void init(String panelToShowcase, Object data) {
+            init(null);
+        }
+        */
+
+        this.init(panelToShowcase, data);
+    }
 
     public void init(String panelToShowcase,Object data){
         this.panelForPlugins = mainPanel.createCustomPanel(mainPanel.getPosition().getWidth(), mainPanel.getPosition().getHeight() - 45, null);


### PR DESCRIPTION
Adds support for:

(1) Opening a specific command UI tab on button click.
(2) Passing any object (e.g. a MarketAPI in the case of TASC) to the init method on CommandUIPlugin objects.

I added this functionality because I wanted to support clicking a button in the colony management screen to open the terraforming menu with that market already selected.

Thanks for taking the time to review this! If you have any questions or would like any changes, just let me know.