### PR TITLE
Bump version to 2.2.0; dedupe CommandTabInterceptor field/if-block from 2.2.0 merge

### DIFF
--- a/ashlib.version
+++ b/ashlib.version
@@ -1,12 +1,12 @@
 {
     "masterVersionFile":"https://raw.githubusercontent.com/Kaysaar/AshLib/refs/heads/master/ashlib.version",
     "modName":"Ashlib",
-    "directDownloadURL":"https://drive.google.com/uc?export=download&id=140ZM70saWVdbh6cDHAz3LJsQo8XivItB",
+    "directDownloadURL":"https://drive.google.com/uc?export=download&id=1PIlXgKygyCIY0FCfuhlQRSrbkzHsSPZx",
     "modThreadId":30808,
     "modVersion":
     {
         "major":2,
-        "minor":1,
-        "patch":2
+        "minor":2,
+        "patch":0
      }
 }

--- a/src/ashlib/data/plugins/coreui/CommandTabInterceptor.java
+++ b/src/ashlib/data/plugins/coreui/CommandTabInterceptor.java
@@ -31,11 +31,6 @@ public class CommandTabInterceptor implements CoreUITabListener, PlayerColonizat
               CommandTabMemoryManager.getInstance().setLastCheckedTab("income");
             }
         }
-        if(tabIdToSwitchToUponOpen != null)
-        {
-            CommandTabMemoryManager.getInstance().setLastCheckedTab(tabIdToSwitchToUponOpen);
-            tabIdToSwitchToUponOpen = null;
-        }
         if(param instanceof MarketAPI){
             CommandTabMemoryManager.getInstance().setLastCheckedTab("colonies");
         }
@@ -52,7 +47,7 @@ public class CommandTabInterceptor implements CoreUITabListener, PlayerColonizat
         }
         CommandTabTracker.sendSignalToOpenCore = true;
     }
-    public static String tabIdToSwitchToUponOpen = null;
+
     @Override
     public void reportPlayerColonizedPlanet(PlanetAPI planet) {
 


### PR DESCRIPTION
## Summary

Two-file PR that brings `master` in line with the public 2.2.0 release and fixes a latent compile error in `CommandTabInterceptor.java`.

- **`ashlib.version`** — bumped to 2.2.0 with the new Google Drive `directDownloadURL`. The 2.2.0 release was built and published with these values, but the bump was never committed/pushed to `master`.
- **`src/ashlib/data/plugins/coreui/CommandTabInterceptor.java`** — removes the duplicate `public static String tabIdToSwitchToUponOpen` field declaration and the duplicate null-check block introduced by the merge at 9189cb7 ("Merge remote-tracking branch 'origin/master'"). The duplicate field is a Java compile error.

## Background

PR #2 (#2, merged in a2028aa) added `tabIdToSwitchToUponOpen` plumbing. While that PR was sitting on `master`, a parallel fork (commit d7e3a79 "2.2.0") independently re-implemented the same plumbing — same field name, same comment, same if-block — but placed the field at a different line and the if-block in a different position within `reportAboutToOpenCoreTab`.

When d7e3a79 was merged back to `master` at 9189cb7, the conflicts in `CommandTabTracker.java` and `CommandUIPlugin.java` were resolved cleanly (the two implementations were textually identical), but `CommandTabInterceptor.java` was resolved by accepting *both* copies of the field declaration and *both* copies of the if-block, producing:

```java
public static String tabIdToSwitchToUponOpen = null;   // #1
// ...
if (tabIdToSwitchToUponOpen != null) { ... }           // #1
if (param instanceof MarketAPI) { ... }
if (param instanceof CommandCustomData data) { ... }
if (tabIdToSwitchToUponOpen != null) { ... }           // #2 (duplicate)
// ...
public static String tabIdToSwitchToUponOpen = null;   // #2 (Java compile error)
```

## Behavioural note on the dedupe

The kept placement is PR #2's: the if-block sits *after* the `MarketAPI`/`CommandCustomData` checks. That ordering is what the surrounding comment describes — `tabIdToSwitchToUponOpen` is meant to override the colony-tab switch that `MarketAPI` would otherwise trigger. The other (pre-MarketAPI) placement from d7e3a79 would have produced the opposite behaviour.

## Test plan

- [ ] `git diff master..HEAD --stat` lists exactly the two files above
- [ ] `CommandTabInterceptor.java` compiles (the duplicate field previously prevented this)
- [ ] In-game smoke test: open the command UI; confirm tab switching still works
- [ ] In-game smoke test: trigger a `tabIdToSwitchToUponOpen` flow (e.g. via the TASC terraforming menu entry point) and confirm the tab switch wins over the colony auto-switch when both fire